### PR TITLE
Even more bracketed paste improvements

### DIFF
--- a/src/fe-text/gui-readline.c
+++ b/src/fe-text/gui-readline.c
@@ -685,7 +685,7 @@ static void paste_bracketed_middle()
 	int len = paste_buffer->len - marklen;
 	unichar *ptr = (unichar *) paste_buffer->data;
 
-	if (len <= 0) {
+	if (len < 0) {
 		return;
 	}
 
@@ -702,10 +702,8 @@ static void paste_bracketed_middle()
 				len -= marklen * 2;
 
 				/* go one step back */
-				if (i > 0) {
-					i--;
-					ptr--;
-				}
+				i--;
+				ptr--;
 				continue;
 			}
 			paste_bracketed_end(i, i != len);

--- a/src/fe-text/gui-readline.c
+++ b/src/fe-text/gui-readline.c
@@ -710,13 +710,12 @@ static void sig_input(void)
 			}
 
 			for (i = 0; i <= len; i++, ptr++) {
-				if (ptr[0] == bp_end[0] && !memcmp(ptr, bp_end, sizeof(bp_end))) {
+				if (ptr[0] == bp_end[0] && memcmp(ptr, bp_end, sizeof(bp_end)) == 0) {
 					paste_bracketed_end(i, i != len);
 					break;
 				}
 			}
-		}
-		else if (paste_detect_time > 0 && paste_buffer->len >= 3) {
+		} else if (paste_detect_time > 0 && paste_buffer->len >= 3) {
 			if (paste_timeout_id != -1)
 				g_source_remove(paste_timeout_id);
 			paste_timeout_id = g_timeout_add(paste_detect_time, paste_timeout, NULL);

--- a/src/fe-text/gui-readline.c
+++ b/src/fe-text/gui-readline.c
@@ -655,7 +655,7 @@ static void paste_bracketed_end(int i, gboolean rest)
 	/* if there's stuff after the end bracket, save it for later */
 	if (rest) {
 		unichar *start = ((unichar *) paste_buffer->data) + i + G_N_ELEMENTS(bp_end);
-		int len = paste_buffer->len - G_N_ELEMENTS(bp_end);
+		int len = paste_buffer->len - i - G_N_ELEMENTS(bp_end);
 
 		g_array_set_size(paste_buffer_rest, 0);
 		g_array_append_vals(paste_buffer_rest, start, len);


### PR DESCRIPTION
Now handles:
- Last line not ending with a newline
- Small pastes that end in the same sig_input() call where they started
- Paste start marker right after the end marker, which is a st bug: http://lists.suckless.org/dev/1509/27328.html
- Empty pastes and sequences of those (just don't do anything)

Ref https://github.com/irssi/irssi/pull/277
